### PR TITLE
Allow the Rotary Hearth Furnace to have distinct buses

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityMegaBlastFurnace.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityMegaBlastFurnace.java
@@ -177,6 +177,11 @@ public class MetaTileEntityMegaBlastFurnace extends GCYMRecipeMapMultiblockContr
     }
 
     @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
+
+    @Override
     public int getCurrentTemperature() {
         return this.blastFurnaceTemperature;
     }


### PR DESCRIPTION
Allows the Rotary Hearth Furnace to have distinct buses, to match the regular EBF which has distinct buses enabled.