### PR TITLE
Fix crash when clicking on parallel hatch on server

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblockpart/MetaTileEntityParallelHatch.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblockpart/MetaTileEntityParallelHatch.java
@@ -65,7 +65,7 @@ public class MetaTileEntityParallelHatch extends MetaTileEntityMultiblockPart im
     protected ModularUI createUI(@Nonnull EntityPlayer entityPlayer) {
         ServerWidgetGroup parallelAmountGroup = new ServerWidgetGroup(() -> true);
         parallelAmountGroup.addWidget(new ImageWidget(62, 36, 53, 20, GuiTextures.DISPLAY)
-                .setTooltip(I18n.format("gcym.machine.parallel_hatch.display")));
+                .setTooltip("gcym.machine.parallel_hatch.display"));
 
         parallelAmountGroup.addWidget(new IncrementButtonWidget(118, 36, 30, 20, 1, 4, 16, 64, this::setCurrentParallel)
                 .setDefaultTooltip()


### PR DESCRIPTION
Fixes a crash when clicking on the Parallel Hatch on a server. Closes #15 