### PR TITLE
Add GTFO recipe maps to GCYM multiblocks

### DIFF
--- a/src/main/java/gregicality/multiblocks/api/GCYMValues.java
+++ b/src/main/java/gregicality/multiblocks/api/GCYMValues.java
@@ -4,4 +4,5 @@ public class GCYMValues {
 
     public static final String GREGIFICATION_MODID = "gregification";
     public static final String GCYS_MODID = "gcys";
+    public static final String GTFO_MODID = "gregtechfoodoption";
 }

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeAssembler.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeAssembler.java
@@ -1,5 +1,6 @@
 package gregicality.multiblocks.common.metatileentities.multiblock.standard;
 
+import gregicality.multiblocks.api.GCYMValues;
 import gregicality.multiblocks.api.metatileentity.GCYMRecipeMapMultiblockController;
 import gregicality.multiblocks.api.render.GCYMTextures;
 import gregicality.multiblocks.common.block.GCYMMetaBlocks;
@@ -9,6 +10,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.cube.OrientedOverlayRenderer;
@@ -16,6 +18,7 @@ import gregtech.common.blocks.BlockGlassCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
 
 import javax.annotation.Nonnull;
 
@@ -24,7 +27,7 @@ import static gregtech.api.util.RelativeDirection.*;
 public class MetaTileEntityLargeAssembler extends GCYMRecipeMapMultiblockController {
 
     public MetaTileEntityLargeAssembler(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, RecipeMaps.ASSEMBLER_RECIPES);
+        super(metaTileEntityId, determineRecipeMaps());
     }
 
     @Override
@@ -73,5 +76,14 @@ public class MetaTileEntityLargeAssembler extends GCYMRecipeMapMultiblockControl
     @Override
     public boolean canBeDistinct() {
         return true;
+    }
+
+    @Nonnull
+    private static RecipeMap<?>[] determineRecipeMaps() {
+        RecipeMap<?> cuisineAssemblerMap = RecipeMap.getByName("cuisine_assembler");
+        if (Loader.isModLoaded(GCYMValues.GTFO_MODID) && cuisineAssemblerMap != null) {
+            return new RecipeMap<?>[]{RecipeMaps.ASSEMBLER_RECIPES, cuisineAssemblerMap};
+        }
+        return new RecipeMap<?>[]{RecipeMaps.ASSEMBLER_RECIPES};
     }
 }

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeCutter.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeCutter.java
@@ -1,5 +1,6 @@
 package gregicality.multiblocks.common.metatileentities.multiblock.standard;
 
+import gregicality.multiblocks.api.GCYMValues;
 import gregicality.multiblocks.api.metatileentity.GCYMRecipeMapMultiblockController;
 import gregicality.multiblocks.api.render.GCYMTextures;
 import gregicality.multiblocks.common.block.GCYMMetaBlocks;
@@ -18,6 +19,7 @@ import gregtech.common.blocks.BlockGlassCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
 
 import javax.annotation.Nonnull;
 
@@ -26,7 +28,7 @@ import static gregtech.api.util.RelativeDirection.*;
 public class MetaTileEntityLargeCutter extends GCYMRecipeMapMultiblockController {
 
     public MetaTileEntityLargeCutter(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, new RecipeMap[]{RecipeMaps.CUTTER_RECIPES, RecipeMaps.LATHE_RECIPES});
+        super(metaTileEntityId, determineRecipeMaps());
     }
 
     @Override
@@ -73,5 +75,14 @@ public class MetaTileEntityLargeCutter extends GCYMRecipeMapMultiblockController
     @Override
     protected OrientedOverlayRenderer getFrontOverlay() {
         return GCYMTextures.LARGE_CUTTER_OVERLAY;
+    }
+
+    @Nonnull
+    private static RecipeMap<?>[] determineRecipeMaps() {
+        RecipeMap<?> slicerMap = RecipeMap.getByName("slicer");
+        if (Loader.isModLoaded(GCYMValues.GTFO_MODID) && slicerMap != null) {
+            return new RecipeMap<?>[]{RecipeMaps.CUTTER_RECIPES, RecipeMaps.LATHE_RECIPES, slicerMap};
+        }
+        return new RecipeMap<?>[]{RecipeMaps.CUTTER_RECIPES, RecipeMaps.LATHE_RECIPES};
     }
 }


### PR DESCRIPTION
This PR simply adds the GTFO slicer recipe map to the large cutter, and the GTFO cuisine assembler recipe map to the large assembler.

Currently, in GTCEu, there is an issue where a multiblock will not display the GTFO recipe maps in its tooltips or in JEI, although only when deployed. This issue is not addressed and does not hope to be addressed in this PR.