### PR TITLE
Fixes #28

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/block/GCYMMetaBlocks.java
+++ b/src/main/java/gregicality/multiblocks/common/block/GCYMMetaBlocks.java
@@ -30,7 +30,7 @@ public class GCYMMetaBlocks {
 
     @SideOnly(Side.CLIENT)
     public static void registerItemModels() {
-        registerItemModel(UNIQUE_CASING);
+        UNIQUE_CASING.onModelRegister();
         registerItemModel(LARGE_MULTIBLOCK_CASING);
     }
 


### PR DESCRIPTION
uses VariantActiveBlock state mapper to register the model so the ACTIVE state is properly evaluated
Fixes VariantActiveBlock models without bloom ( heat vent, crushing wheels, slicing blades ) having full bloom