### PR TITLE
Changes the minimum number High temperature casings on the ABS

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityAlloyBlastSmelter.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityAlloyBlastSmelter.java
@@ -102,7 +102,7 @@ public class MetaTileEntityAlloyBlastSmelter extends RecipeMapMultiblockControll
                 .aisle("XXXXX", "CAAAC", "GAAAG", "CAAAC", "XXXXX")
                 .aisle("#XSX#", "#CCC#", "#GGG#", "#CCC#", "#XXX#")
                 .where('S', selfPredicate())
-                .where('X', states(getCasingState()).setMinGlobalLimited(30).or(autoAbilities(true, true, true, true, true, true, false)))
+                .where('X', states(getCasingState()).setMinGlobalLimited(20).or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('C', heatingCoils())
                 .where('G', states(getCasingState2()))
                 .where('M', abilities(MultiblockAbility.MUFFLER_HATCH))


### PR DESCRIPTION
Going from 30 to 20 so that it's easier to use the new alloy smelter recipes with multiple hatches. 
By request of StarL0st