### PR TITLE
Add distinct bus mode to Large Wiremill

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeWiremill.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeWiremill.java
@@ -66,4 +66,9 @@ public class MetaTileEntityLargeWiremill extends GCYMRecipeMapMultiblockControll
     protected OrientedOverlayRenderer getFrontOverlay() {
         return GCYMTextures.LARGE_WIREMILL_OVERLAY;
     }
+
+    @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
 }


### PR DESCRIPTION
Because all wiremill recipes now require a programmed circuit, this is needed for the large wiremill to work properly.