### PR TITLE
Enable Bus Distinction in LCA

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeCircuitAssembler.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeCircuitAssembler.java
@@ -69,6 +69,11 @@ public class MetaTileEntityLargeCircuitAssembler extends GCYMRecipeMapMultiblock
     }
 
     @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
+
+    @Override
     public ICubeRenderer getBaseTexture(IMultiblockPart iMultiblockPart) {
         return GCYMTextures.ASSEMBLING_CASING;
     }


### PR DESCRIPTION
Enable Bus Distinction in Large Circuit Assembler. This change should considerably increase QoL.