### PR TITLE
2.8 fixes

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/block/blocks/BlockUniqueCasing.java
+++ b/src/main/java/gregicality/multiblocks/common/block/blocks/BlockUniqueCasing.java
@@ -40,7 +40,7 @@ public class BlockUniqueCasing extends VariantActiveBlock<BlockUniqueCasing.Uniq
             if (layer == BlockRenderLayer.SOLID) return true;
         } else if (layer == BlockRenderLayer.CUTOUT) return true;
 
-        if (isBloomEnabled(type)) return layer == BloomEffectUtil.getRealBloomLayer();
+        if (isBloomEnabled(type)) return layer == BloomEffectUtil.getEffectiveBloomLayer(layer);
         return layer == BlockRenderLayer.CUTOUT;
     }
 

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/generator/MetaTileEntitySteamEngine.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/generator/MetaTileEntitySteamEngine.java
@@ -65,8 +65,8 @@ public class MetaTileEntitySteamEngine extends FuelMultiblockController {
             IEnergyContainer container = mte.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
             return container != null && container.getOutputVoltage() <= GTValues.V[GTValues.MV];
         }).toArray(MetaTileEntity[]::new))
-                .addTooltip("gregtech.multiblock.pattern.error.limited.1", GTValues.VN[GTValues.MV])
-                .addTooltip("gregtech.multiblock.pattern.error.limited.0", GTValues.VN[GTValues.LV]);
+                .addTooltip("gregtech.multiblock.pattern.error.limited.1", GTValues.VN[GTValues.LV])
+                .addTooltip("gregtech.multiblock.pattern.error.limited.0", GTValues.VN[GTValues.MV]);
     }
 
     private static IBlockState getCasingState() {

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
@@ -50,7 +50,7 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
 
     @Override
     protected Function<BlockPos, Integer> multiblockPartSorter() {
-        return BlockPos::getY; // todo this needs to be "relative up" with Freedom Wrench
+        return UP.getSorter(getFrontFacing(), getUpwardsFacing(), isFlipped());
     }
 
     @Override
@@ -69,7 +69,7 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
                 .aisle("#YYY#", "YYYYY", "YYYYY", "YYYYY", "#YYY#")
                 .where('S', selfPredicate())
                 .where('Y', casingPredicate.or(abilities(MultiblockAbility.IMPORT_ITEMS))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1))
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS))
                         .or(abilities(GCYMMultiblockAbility.PARALLEL_HATCH).setMaxGlobalLimited(1).setPreviewCount(1))
@@ -128,6 +128,11 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
 
     @Override
     public boolean isTiered() {
+        return false;
+    }
+
+    @Override
+    public boolean allowsExtendedFacing() {
         return false;
     }
 }


### PR DESCRIPTION
- Fix large DT being rotatable
- Fix large DT allowing more than 2 energy hatches
- Update bloom layer check to use a non-deprecated method
- Fix Large Steam Engine allowing Dynamo Hatches above MV