### PR TITLE
Do not check anymore if Gregification is loaded

### DIFF
--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeSifter.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeSifter.java
@@ -75,7 +75,7 @@ public class MetaTileEntityLargeSifter extends GCYMRecipeMapMultiblockController
 
     private static @NotNull RecipeMap<?> @NotNull [] determineRecipeMaps() {
         RecipeMap<?> sieveMap = RecipeMap.getByName("electric_sieve");
-        if (Loader.isModLoaded(GCYMValues.GREGIFICATION_MODID) && sieveMap != null) {
+        if (sieveMap != null) {
             return new RecipeMap<?>[] { RecipeMaps.SIFTER_RECIPES, sieveMap };
         }
         return new RecipeMap<?>[] { RecipeMaps.SIFTER_RECIPES };


### PR DESCRIPTION
## What
Since Gregification isn't a thing anymore, do not check if it's loaded in the large sifter.

## Implementation Details
Remove the check.

## Outcome
Only checks if the electric_sieve recipemap exists.

## Additional Information
Life is an illusion.

## Potential Compatibility Issues
None I could be aware of.
