### PR TITLE
Fix Missing ABS Recipes for Alloys Without Molten Fluids

### DIFF
--- a/src/main/java/gregicality/multiblocks/api/fluids/GeneratedFluidHandler.java
+++ b/src/main/java/gregicality/multiblocks/api/fluids/GeneratedFluidHandler.java
@@ -1,5 +1,7 @@
 package gregicality.multiblocks.api.fluids;
 
+import net.minecraftforge.fluids.Fluid;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -50,7 +52,11 @@ public final class GeneratedFluidHandler {
                     .temperature(alloyBlastProperty.getTemperature()));
         } else {
             // not hot enough to produce molten fluid, so produce regular fluid
-            fluidProperty.getStorage().store(GCYMFluidStorageKeys.MOLTEN, material.getFluid(FluidStorageKeys.LIQUID));
+            FluidBuilder liquidBuilder = fluidProperty.getStorage().getQueuedBuilder(FluidStorageKeys.LIQUID);
+            if (liquidBuilder == null) return;
+
+            Fluid fluid = liquidBuilder.build(material.getModid(), material, FluidStorageKeys.LIQUID);
+            fluidProperty.getStorage().store(GCYMFluidStorageKeys.MOLTEN, fluid);
         }
     }
 }

--- a/src/main/java/gregicality/multiblocks/api/fluids/GeneratedFluidHandler.java
+++ b/src/main/java/gregicality/multiblocks/api/fluids/GeneratedFluidHandler.java
@@ -1,13 +1,10 @@
 package gregicality.multiblocks.api.fluids;
 
-import net.minecraftforge.fluids.Fluid;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.FluidBuilder;
-import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty;
 import gregtech.api.unification.material.properties.FluidProperty;
@@ -50,13 +47,8 @@ public final class GeneratedFluidHandler {
         if (alloyBlastProperty.shouldGenerateMolten(material)) {
             fluidProperty.getStorage().enqueueRegistration(GCYMFluidStorageKeys.MOLTEN, new FluidBuilder()
                     .temperature(alloyBlastProperty.getTemperature()));
-        } else {
-            // not hot enough to produce molten fluid, so produce regular fluid
-            FluidBuilder liquidBuilder = fluidProperty.getStorage().getQueuedBuilder(FluidStorageKeys.LIQUID);
-            if (liquidBuilder == null) return;
-
-            Fluid fluid = liquidBuilder.build(material.getModid(), material, FluidStorageKeys.LIQUID);
-            fluidProperty.getStorage().store(GCYMFluidStorageKeys.MOLTEN, fluid);
         }
+        // if it is not hot enough to produce molten fluid, ABS Producer grabs normal liquid,
+        // thus we don't need to do anything.
     }
 }

--- a/src/main/java/gregicality/multiblocks/api/recipes/alloyblast/AlloyBlastRecipeProducer.java
+++ b/src/main/java/gregicality/multiblocks/api/recipes/alloyblast/AlloyBlastRecipeProducer.java
@@ -47,20 +47,23 @@ public class AlloyBlastRecipeProducer {
         if (componentAmount < 2) return;
 
         // get the output fluid
-        Fluid molten = material.getFluid(GCYMFluidStorageKeys.MOLTEN);
-        if (molten == null) return;
+        Fluid output = material.getFluid(GCYMFluidStorageKeys.MOLTEN);
+        if (output == null) {
+            output = material.getFluid(FluidStorageKeys.LIQUID);
+            if (output == null) return;
+        }
 
         RecipeBuilder<BlastRecipeBuilder> builder = createBuilder(blastProperty, material);
 
         int outputAmount = addInputs(material, builder);
         if (outputAmount <= 0) return;
 
-        buildRecipes(blastProperty, molten, outputAmount, componentAmount, builder);
+        buildRecipes(blastProperty, output, outputAmount, componentAmount, builder);
 
         // if the material does not need a vacuum freezer, exit
         if (!OrePrefix.ingotHot.doGenerateItem(material)) return;
 
-        addFreezerRecipes(material, molten, blastProperty);
+        addFreezerRecipes(material, output, blastProperty);
     }
 
     /**


### PR DESCRIPTION
## What
Fix Missing ABS Recipes for Alloys Without Molten Fluids (again)

## Implementation Details
Initially, in https://github.com/GregTechCEu/gregicality-multiblocks/commit/4d549f2f58aeb6341f8ae1c64619faec6b741ee6, I fixed the code which grabbed the material's liquid. However, this caused a double tooltip:
![image](https://github.com/GregTechCEu/gregicality-multiblocks/assets/103940576/c32edd36-9cb5-49ee-97bd-5dd67253763b)

The double tooltip was due to there being two fluid storage keys pointing to the same fluid.

Therefore, I changed it so that ABS Recipe Producers tries to grab the liquid key, if molten is not available. Because the restrictions to get to this point are the same regardless if a molten fluid is available or not, the implementation should have been restored to its original behaviour.

## Outcome
Fix Missing ABS Recipes for Alloys Without Molten Fluids