### PR TITLE
Fix Hard Dependancy on MUI2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,5 +38,5 @@
  * For more details, see https://docs.gradle.org/8.4/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("gregtech:gregtech:2.8.9-beta")
+    api("gregtech:gregtech:2.8.10-beta")
 }

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
@@ -4,8 +4,9 @@ import static gregtech.api.util.RelativeDirection.*;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
+import gregtech.api.capability.IDistillationTower;
+import gregtech.api.capability.impl.DistillationTowerLogicHandler;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -13,19 +14,13 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.cleanroommc.modularui.utils.FluidTankHandler;
-
 import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -59,21 +54,33 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
  * Requires an unfortunate amount of copy-pasted logic from
  * {@link gregtech.common.metatileentities.multi.electric.MetaTileEntityDistillationTower}
  */
-public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockController {
+public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockController implements IDistillationTower {
 
-    protected int layerCount;
-    protected List<IFluidHandler> orderedFluidOutputs;
+    protected DistillationTowerLogicHandler handler = null;
 
     public MetaTileEntityLargeDistillery(ResourceLocation metaTileEntityId) {
+        this(metaTileEntityId, false);
+    }
+
+    public MetaTileEntityLargeDistillery(ResourceLocation metaTileEntityId, boolean useAdvHatchLogic) {
         super(metaTileEntityId, new RecipeMap[] { RecipeMaps.DISTILLATION_RECIPES, RecipeMaps.DISTILLERY_RECIPES });
         this.recipeMapWorkable = new LargeDistilleryRecipeLogic(this);
+        if (useAdvHatchLogic)
+            this.handler = new DistillationTowerLogicHandler(this);
     }
 
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
-        return new MetaTileEntityLargeDistillery(this.metaTileEntityId);
+        return new MetaTileEntityLargeDistillery(this.metaTileEntityId, usesAdvHatchLogic());
     }
 
+    /**
+     * Used if MultiblockPart Abilities need to be sorted a certain way, like
+     * Distillation Tower and Assembly Line. <br>
+     * <br>
+     * There will be <i>consequences</i> if this is changed. Make sure to set the logic handler to one with
+     * a properly overriden {@link DistillationTowerLogicHandler#determineOrderedFluidOutputs()}
+     */
     @Override
     protected Function<BlockPos, Integer> multiblockPartSorter() {
         return RelativeDirection.UP.getSorter(getFrontFacing(), getUpwardsFacing(), isFlipped());
@@ -81,7 +88,9 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
 
     /**
      * Whether this multi can be rotated or face upwards. <br>
-     * There will be <i>consequences</i> if this returns true. Go override {@link #determineOrderedFluidOutputs()}
+     * <br>
+     * There will be <i>consequences</i> if this returns true. Make sure to set the logic handler to one with
+     * a properly overriden {@link DistillationTowerLogicHandler#determineOrderedFluidOutputs()}
      */
     @Override
     public boolean allowsExtendedFacing() {
@@ -108,72 +117,19 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
         if (!usesAdvHatchLogic() || this.structurePattern == null) return;
-        this.layerCount = determineLayerCount(this.structurePattern);
-        this.orderedFluidOutputs = determineOrderedFluidOutputs();
+        handler.determineLayerCount(this.structurePattern);
+        handler.determineOrderedFluidOutputs();
     }
 
     protected boolean usesAdvHatchLogic() {
-        return getCurrentRecipeMap() == RecipeMaps.DISTILLATION_RECIPES;
-    }
-
-    /**
-     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
-     *
-     * @param structurePattern the structure pattern
-     * @return the number of layers that <b>could</b> hold output hatches
-     */
-    protected int determineLayerCount(@NotNull BlockPattern structurePattern) {
-        return structurePattern.formedRepetitionCount[1] + 1;
-    }
-
-    /**
-     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
-     *
-     * @return the fluid hatches of the multiblock, in order, with null entries for layers that do not have hatches.
-     */
-    protected List<IFluidHandler> determineOrderedFluidOutputs() {
-        List<MetaTileEntityMultiblockPart> fluidExportParts = this.getMultiblockParts().stream()
-                .filter(iMultiblockPart -> iMultiblockPart instanceof IMultiblockAbilityPart<?>abilityPart &&
-                        abilityPart.getAbility() == MultiblockAbility.EXPORT_FLUIDS &&
-                        abilityPart instanceof MetaTileEntityMultiblockPart)
-                .map(iMultiblockPart -> (MetaTileEntityMultiblockPart) iMultiblockPart)
-                .collect(Collectors.toList());
-        // the fluidExportParts should come sorted in smallest Y first, largest Y last.
-        List<IFluidHandler> orderedHandlerList = new ObjectArrayList<>();
-        int firstY = this.getPos().getY() + 1;
-        int exportIndex = 0;
-        for (int y = firstY; y < firstY + this.layerCount; y++) {
-            if (fluidExportParts.size() <= exportIndex) {
-                orderedHandlerList.add(null);
-                continue;
-            }
-            MetaTileEntityMultiblockPart part = fluidExportParts.get(exportIndex);
-            if (part.getPos().getY() == y) {
-                List<IFluidTank> hatchTanks = new ObjectArrayList<>();
-                // noinspection unchecked
-                ((IMultiblockAbilityPart<IFluidTank>) part).registerAbilities(hatchTanks);
-                if (hatchTanks.size() == 1)
-                    orderedHandlerList.add(FluidTankHandler.getTankFluidHandler(hatchTanks.get(0)));
-                else orderedHandlerList.add(new FluidTankList(false, hatchTanks));
-                exportIndex++;
-            } else if (part.getPos().getY() > y) {
-                orderedHandlerList.add(null);
-            } else {
-                GCYMLog.logger.error(
-                        "The Distillation Tower at {} had a fluid export hatch with an unexpected Y position.",
-                        this.getPos());
-                this.invalidateStructure();
-                return new ObjectArrayList<>();
-            }
-        }
-        return orderedHandlerList;
+        return getCurrentRecipeMap() == RecipeMaps.DISTILLATION_RECIPES && this.handler != null;
     }
 
     @Override
     public void invalidateStructure() {
         super.invalidateStructure();
-        this.layerCount = 0;
-        this.orderedFluidOutputs = null;
+        if (usesAdvHatchLogic())
+            this.handler.invalidate();
     }
 
     @Override
@@ -211,7 +167,7 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
     }
 
     @Override
-    protected boolean allowSameFluidFillForOutputs() {
+    public boolean allowSameFluidFillForOutputs() {
         return !usesAdvHatchLogic();
     }
 
@@ -240,7 +196,8 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
 
     @Override
     public int getFluidOutputLimit() {
-        return this.layerCount;
+        if (usesAdvHatchLogic()) return this.handler.getLayerCount();
+        else return super.getFluidOutputLimit();
     }
 
     @Override
@@ -259,25 +216,11 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
             super(tileEntity);
         }
 
-        protected boolean applyFluidToOutputs(@NotNull List<FluidStack> fluids, boolean doFill) {
-            boolean valid = true;
-            for (int i = 0; i < fluids.size(); i++) {
-                IFluidHandler handler = orderedFluidOutputs.get(i);
-                // void if no hatch is found on that fluid's layer
-                // this is considered trimming and thus ignores canVoid
-                if (handler == null) continue;
-                int accepted = handler.fill(fluids.get(i), doFill);
-                if (accepted != fluids.get(i).amount) valid = false;
-                if (!doFill && !valid) break;
-            }
-            return valid;
-        }
-
         @Override
         protected void outputRecipeOutputs() {
             if (usesAdvHatchLogic()) {
                 GTTransferUtils.addItemsToItemHandler(getOutputInventory(), false, itemOutputs);
-                this.applyFluidToOutputs(fluidOutputs, true);
+                handler.applyFluidToOutputs(fluidOutputs, true);
             } else {
                 super.outputRecipeOutputs();
             }
@@ -311,7 +254,7 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
 
             // Perform layerwise fluid checks
             if (!metaTileEntity.canVoidRecipeFluidOutputs() &&
-                    !this.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
+                    !handler.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
                 this.isOutputsFull = true;
                 return false;
             }
@@ -322,6 +265,11 @@ public class MetaTileEntityLargeDistillery extends GCYMRecipeMapMultiblockContro
                 return true;
             }
             return false;
+        }
+
+        @Override
+        protected IMultipleTankHandler getOutputTank() {
+            return handler.getFluidTanks();
         }
     }
 }

--- a/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
+++ b/src/main/java/gregicality/multiblocks/common/metatileentities/multiblock/standard/MetaTileEntityLargeDistillery.java
@@ -5,8 +5,6 @@ import static gregtech.api.util.RelativeDirection.*;
 import java.util.List;
 import java.util.function.Function;
 
-import gregtech.api.capability.IDistillationTower;
-import gregtech.api.capability.impl.DistillationTowerLogicHandler;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -18,7 +16,9 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
 
+import gregtech.api.capability.IDistillationTower;
 import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.capability.impl.DistillationTowerLogicHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
@@ -37,18 +37,14 @@ import gregtech.client.renderer.texture.cube.OrientedOverlayRenderer;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockBoilerCasing;
 import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.core.sound.GTSoundEvents;
 
 import gregicality.multiblocks.api.capability.impl.GCYMMultiblockRecipeLogic;
 import gregicality.multiblocks.api.metatileentity.GCYMMultiblockAbility;
 import gregicality.multiblocks.api.metatileentity.GCYMRecipeMapMultiblockController;
 import gregicality.multiblocks.api.render.GCYMTextures;
-import gregicality.multiblocks.api.utils.GCYMLog;
 import gregicality.multiblocks.common.block.GCYMMetaBlocks;
 import gregicality.multiblocks.common.block.blocks.BlockLargeMultiblockCasing;
-
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 /**
  * Requires an unfortunate amount of copy-pasted logic from


### PR DESCRIPTION
## What
fixes an accidental hard dependancy on a mui2 class copied from GTCEu, which would cause CEu's jei module to fail to load.

## Implementation Details
updates the ceu dep to 2.8.10
update the large distillation tower to match changes to the normal distillation tower

## Outcome
jei is not kill
