### PR TITLE
Don't generate ABS recipes with > 9 dusts

### DIFF
--- a/src/main/java/gregicality/multiblocks/api/recipes/alloyblast/AlloyBlastRecipeProducer.java
+++ b/src/main/java/gregicality/multiblocks/api/recipes/alloyblast/AlloyBlastRecipeProducer.java
@@ -98,11 +98,14 @@ public class AlloyBlastRecipeProducer {
         // calculate the output amount and add inputs
         int outputAmount = 0;
         int fluidAmount = 0;
+        int dustAmount = 0;
         for (MaterialStack materialStack : material.getMaterialComponents()) {
             final Material msMat = materialStack.material;
             final int msAmount = (int) materialStack.amount;
 
             if (msMat.hasProperty(PropertyKey.DUST)) {
+                if (dustAmount >= 9) return -1; // more than 9 dusts won't fit in the machine
+                dustAmount++;
                 builder.input(OrePrefix.dust, msMat, msAmount);
             } else if (msMat.hasProperty(PropertyKey.FLUID)) {
                 if (fluidAmount >= 2) return -1; // more than 2 fluids won't fit in the machine


### PR DESCRIPTION
Actually check that generated ABS recipes won't overflow the item inputs on the recipe map, same as is done for fluids
